### PR TITLE
Run service as unprivileged user

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,18 @@ A respondd server written in node.js.
 2. On `systemd` based systems, copy `node-respondd.service` to `/etc/systemd/system/respondd.service`
    and run `systemctl enable node-respondd`.
    On systems without `systemd`, check how to install services.
-3. Configure sudo.
+3. Create unprivileged system user for respondd (`adduser --system respondd`).
+4. Configure sudo.
 
 ### sudo configuration
 
 *node-respondd* requires *sudo* to be set up and configured, such that `bat-list-neighbours` can be 
 executed with root privileges by `respondd`. If you use the `respondd.service` for *systemd*, this would
-be for user `nobody`.
+be for user `respondd`.
 
 A possible way to extend suoders file accordingly would be:
 
-    nobody ALL=(root) NOPASSWD: /opt/node-respondd/bat-list-neighbours
+    respondd ALL=(root) NOPASSWD: /opt/node-respondd/bat-list-neighbours
 
 ## Configuration
 

--- a/node-respondd.service
+++ b/node-respondd.service
@@ -3,6 +3,8 @@ Description=The node-respondd server provides data about this node to the local 
 
 [Service]
 Type=simple
+User=respondd
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 WorkingDirectory=/opt/node-respondd
 ExecStart=/opt/node-respondd/respondd
 

--- a/respondd
+++ b/respondd
@@ -232,7 +232,9 @@ socket.on('listening', () => {
 
 socket.bind(getConfig("port"), () => {
   socket.addMembership(getConfig("mcast_group"), getConfig("listen"))
-  myproc.setgid('nogroup')
-  myproc.setuid('nobody')
+  if (myproc.getgid() == 0 || myproc.getuid() == 0) {
+    myproc.setgid('nogroup')
+    myproc.setuid('respondd')
+  }
 })
 


### PR DESCRIPTION
Debian 13 (trixie) ships with nodejs v20. This version blocks calls to `setuid()` and `setgid()` (which are needed to drop privileges after binding to a port), because of security concerns regarding `io_uring`. Setting `kernel.io_uring_disabled = 2` using sysctl does not convince nodejs to unblock the calls, and neither does setting `UV_USE_IO_URING=0` via environment variables.

### MWE
Executing this as root crashes on Debian 13 / nodejs v20.19.2:
```javascript
process = require("process");
os = require("os");

console.log(os.userInfo());
process.setgid("nogroup");
process.setuid("nobody");
console.log(os.userInfo());
```
> Error: setgid() disabled: io_uring may be enabled. See CVE-2024-22017.

### Solution
Instead of dropping privileges, let systemd execute the process with reduced privilege from the beginning. In order to bind to privileged ports, add the CAP_NET_BIND_SERVICE capability (via systemd).
If respondd is run as root anyway, attempt to drop privileges like before.

Additionally, I adapted the documentation to suggest creating a dedicated linux user for respondd, because running services as `nobody` [is a discouraged practice](https://wiki.ubuntu.com/nobody) and systemd is unhappy if we do.